### PR TITLE
Replace an empty return with a cast temporarily

### DIFF
--- a/ballerina/modules/types.any/any.bal
+++ b/ballerina/modules/types.any/any.bal
@@ -99,10 +99,9 @@ isolated function getUrlSuffixFromValue(ValueType anyMessage) returns string {
         return "google.protobuf.Empty";
     } else if anyMessage is record {||} {
         return "google.protobuf.Empty";
-    } else if anyMessage is record {} {
-        return externGetNameFromRecord(anyMessage);
+    } else {
+        return externGetNameFromRecord(<record {}> anyMessage);
     }
-    return "";
 }
 
 isolated function externGetNameFromRecord(record {} rec) returns string = @java:Method {


### PR DESCRIPTION
## Purpose
With https://github.com/ballerina-platform/ballerina-lang/pull/34709 narrowing will be improved no longer needing the change in https://github.com/ballerina-platform/module-ballerina-protobuf/commit/219226a28213a27d7ae0d939a7d1e1697231f7d7. Once the PR is merged and the lang version is updated we can get rid of the cast.