### PR TITLE
Add identifiers to the `protobuf-java` dependency

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "protobuf"
-version = "1.6.1"
+version = "1.6.2"
 authors = ["Ballerina"]
 keywords = ["wrappers"]
 repository = "https://github.com/ballerina-platform/module-ballerina-protobuf"
@@ -16,8 +16,11 @@ graalvmCompatible = true
 [[platform.java17.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "protobuf-native"
-version = "1.6.1"
-path = "../native/build/libs/protobuf-native-1.6.1.jar"
+version = "1.6.2"
+path = "../native/build/libs/protobuf-native-1.6.2-SNAPSHOT.jar"
 
 [[platform.java17.dependency]]
+groupId = "com.google.protobuf"
+artifactId = "protobuf-java"
+version = "3.25.5"
 path = "./lib/protobuf-java-3.25.5.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -27,7 +27,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "protobuf"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"},

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -20,4 +20,7 @@ version = "@toml.version@"
 path = "../native/build/libs/protobuf-native-@project.version@.jar"
 
 [[platform.java17.dependency]]
+groupId = "com.google.protobuf"
+artifactId = "protobuf-java"
+version = "@protobuf.java.version@"
 path = "./lib/protobuf-java-@protobuf.java.version@.jar"


### PR DESCRIPTION
## Purpose
This fixes the conflicting jar issues for the `protobuf-java` dependency in the `grpc` library
https://github.com/ballerina-platform/ballerina-library/issues/7028