### PR TITLE
Upgrade Gradle to 9.5.1 and Ballerina Gradle plugin to 4.0.0

### DIFF
--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -15,6 +15,13 @@
  *
  */
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -78,8 +85,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml"

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -46,3 +46,5 @@ artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
 artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
+
+test.mustRunAfter(downloadCheckstyleRuleFiles)

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,6 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn('protobuf-ballerina:build')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,14 @@ release {
     }
 }
 
-tasks.named('build') {
-    dependsOn('protobuf-ballerina:build')
+if (tasks.names.contains('build')) {
+    tasks.named('build') {
+        dependsOn('protobuf-ballerina:build')
+
+    }
+} else {
+    tasks.register('build') {
+        dependsOn('protobuf-ballerina:build')
+
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,13 +6,13 @@ ballerinaLangVersion=2201.12.0
 checkstylePluginVersion=10.12.0
 testngVersion=7.6.1
 slf4jVersion=1.7.30
-jacocoVersion=0.8.10
+jacocoVersion=0.8.14
 protobufJavaVersion=3.25.5
-spotbugsPluginVersion=6.0.18
+spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=7.1.2
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
-ballerinaGradlePluginVersion=2.3.0
+releasePluginVersion=3.1.0
+ballerinaGradlePluginVersion=4.0.0
 
 #stdlib dependencies
 stdlibTimeVersion=2.7.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -71,7 +71,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'protobuf'
@@ -42,9 +42,9 @@ project(':checkstyle').projectDir = file("build-config${File.separator}checkstyl
 project(':protobuf-native').projectDir = file('native')
 project(':protobuf-ballerina').projectDir = file('ballerina')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+        termsOfUseAgree = 'yes'
     }
 }


### PR DESCRIPTION
## Summary
- Upgrade the Gradle wrapper to 9.5.1 (with distribution checksum) and the Ballerina Gradle plugin to 4.0.0, needed for Java 21/25 compatibility.
- Fix Gradle 9 breakage: `project.exec` calls now use an injected `ExecOperations`, `com.gradle.enterprise` is migrated to `com.gradle.develocity`, any `task build {}` redefinition is replaced with `tasks.named('build')`, and checkstyle's `build.gradle` drops the deprecated `buildDir` property.

## Test plan
- [x] `./gradlew clean build` passes locally on Gradle 9.5.1 with plugin 4.0.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Upgrade Gradle to 9.5.1 with distribution checksum verification.
- Upgrade the Ballerina Gradle plugin and related build tools for Java 21 and Java 25 compatibility.
- Update build scripts for Gradle 9 APIs, lazy task configuration, and modern directory providers.
- Add task ordering for Checkstyle rule downloads and tests.
- Migrate build scan configuration from Gradle Enterprise to Develocity.
- Confirm that `./gradlew clean build` passes with the updated versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->